### PR TITLE
Stop R1D2 from crashing when None appears in result from server

### DIFF
--- a/r1/menu.py
+++ b/r1/menu.py
@@ -65,6 +65,8 @@ def get_menu(restaurant):
     menu = []
     for d, ms in enumerate(items):
         day = first_day + timedelta(days=d)
+        while None in ms:
+            ms.remove(None)
         for (name, price), t in zip(ms, day_structure):
             menu.append(MenuItem(restaurant, day, t, name, price,
                                  params['currency']))


### PR DESCRIPTION
The current R1D2 failures are happening because "Nones" are being inserted at the end of the page structure that's being iterated through in r1.menu.get_menu. This commit fixes this by manually pruning them.

I didn't try to figure out *why* None is appearing in the page structure that's passed to get_menu; maybe that would be a better solution. But this works for now!